### PR TITLE
NIT: Consider using public linkedin page

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -4,7 +4,7 @@
 
 #### My links
 
- - ![Linkedin icon](/images/linkedin_icon.png) [Linkedin](https://www.linkedin.com/in/marcos-victor-muller-martins-7193b4289/)
+ - ![Linkedin icon](/images/linkedin_icon.png) [Linkedin](https://www.linkedin.com/in/marcosvmmartins/)
  - ![Github icon](/images/github.png) [Github](https://github.com/Alemoum)
  - [Curriculum](/blog/curriculum/curriculum)
 


### PR DESCRIPTION
# Patch Notes:

* Refactor Linkedin URL to use public link

## Summary

When viewing the page, the linkedin link lead to a linkedin error page claiming the "page at that url can not be found". Searching for user by name given, lead to a valid public profile on linkedin, this patch aims to update the content to the working link. Hopefully this helps.

## Rationale

Linkedin has two views for every profile: an owner view (previous url) and a public view for everyone else (corrected URL)
It probably makes more sense to use the public url.